### PR TITLE
Fix physics labs mobile issues

### DIFF
--- a/public/physics-labs/ph12-u1-free-fall-lab-2d-projectiles.html
+++ b/public/physics-labs/ph12-u1-free-fall-lab-2d-projectiles.html
@@ -105,8 +105,33 @@ body.pdf-tall-export .pdf-page {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -755,6 +780,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -767,7 +834,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/ph12-u2-force-table-lab.html
+++ b/public/physics-labs/ph12-u2-force-table-lab.html
@@ -105,8 +105,33 @@ body.pdf-tall-export .pdf-page {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -755,6 +780,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -767,7 +834,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/ph12-u3a-artificial-gravity-lab.html
+++ b/public/physics-labs/ph12-u3a-artificial-gravity-lab.html
@@ -105,8 +105,33 @@ body.pdf-tall-export .pdf-page {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -755,6 +780,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -767,7 +834,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/ph12-u4-collision-forensics-lab.html
+++ b/public/physics-labs/ph12-u4-collision-forensics-lab.html
@@ -105,8 +105,33 @@ body.pdf-tall-export .pdf-page {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -755,6 +780,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -767,7 +834,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/ph12-u5-coulomb-s-law-virtual-lab.html
+++ b/public/physics-labs/ph12-u5-coulomb-s-law-virtual-lab.html
@@ -91,8 +91,33 @@ body {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -490,6 +515,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -502,7 +569,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/ph12-u6-dc-motor-lab.html
+++ b/public/physics-labs/ph12-u6-dc-motor-lab.html
@@ -105,8 +105,33 @@ body.pdf-tall-export .pdf-page {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -755,6 +780,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -767,7 +834,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/ph12-u7-induction-lab.html
+++ b/public/physics-labs/ph12-u7-induction-lab.html
@@ -105,8 +105,33 @@ body.pdf-tall-export .pdf-page {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -755,6 +780,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -767,7 +834,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';

--- a/public/physics-labs/physics-12-formula-sheet.html
+++ b/public/physics-labs/physics-12-formula-sheet.html
@@ -91,8 +91,33 @@ body {
 
 @media screen and (max-width: 600px) {
   body {
-    margin: 10px auto;
-    padding: 1.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .pdf-page {
+    padding: 1rem !important; /* Proper margin for mobile */
+  }
+
+  /* Reset math block to stay within bounds on mobile instead of using negative inches */
+  .math-block {
+    margin: 0.5em 0 !important;
+    width: 100% !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* space for scrollbar */
+  }
+
+  .table-wrapper {
+    width: 100% !important;
+    margin: 1em 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
   }
 }
 
@@ -490,6 +515,48 @@ tr:nth-child(even) { background-color: #fcfcfc; }
     box-shadow: none !important;
   }
 }
+
+
+/* Mobile Overrides for Physics Labs */
+@media screen and (max-width: 600px) {
+  body {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  .pdf-page {
+    padding: 1rem 1rem !important; /* Narrower margins on mobile */
+    overflow-x: hidden; /* Prevent body scroll from inner elements */
+  }
+
+  /* Tables */
+  .table-wrapper {
+    width: 100% !important;
+    margin-left: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  /* Math formulas */
+  .math-block {
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+    display: block !important;
+  }
+
+  .katex-display {
+    overflow-x: auto !important;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem; /* give space for scrollbar */
+    margin: 0 !important;
+    text-align: left !important;
+  }
+}
 </style>
 <script>
 window.addEventListener('load', () => {
@@ -502,7 +569,8 @@ window.addEventListener('load', () => {
         block.style.marginBottom = '';
         const naturalWidth = katexInner.offsetWidth;
         const blockWidth = block.offsetWidth;
-        if (naturalWidth > blockWidth && blockWidth > 0) {
+        const isMobile = window.innerWidth <= 600;
+        if (!isMobile && naturalWidth > blockWidth && blockWidth > 0) {
           const scale = (blockWidth - 4) / naturalWidth;
           katexDisplay.style.transform = 'scale(' + scale + ')';
           katexDisplay.style.transformOrigin = 'center top';


### PR DESCRIPTION
- Reduced mobile margin/padding on the main page `.pdf-page` class so content fits better
- Enabled horizontal scrolling for wide `table` elements (`.table-wrapper`) and large formulas (`.math-block` & `.katex-display`) via `overflow-x: auto`
- Overrode the JavaScript dynamically scaling `.math-block` which was compressing items on mobile instead of letting them scroll.

---
*PR created automatically by Jules for task [3087257197105603729](https://jules.google.com/task/3087257197105603729) started by @mattdanielmurphy*